### PR TITLE
Fix config block for languages

### DIFF
--- a/config/_default/languages.en.yml
+++ b/config/_default/languages.en.yml
@@ -1,20 +1,16 @@
 languageCode: en
 languageName: English
-displayName: EN
-isoCode: en
 weight: 1
-rtl: false
 
 title: David Witkowski
 # description: My awesome website
 # copyright: 'Copy, _right?_ :thinking_face:'
 
-dateFormat: 2 January 2006
-
 params:
-  # mainSections:
-  #   - section1
-  #   - section2
+  displayName: EN
+  isoCode: en
+  rtl: false
+  dateFormat: 2 January 2006
 
 author:
   name: David Witkowski

--- a/layouts/partials/header/basic.html
+++ b/layouts/partials/header/basic.html
@@ -104,7 +104,7 @@
               </button>
             </li>
           {{ end }}
-
+          <span class="px-2 text-primary-500"></span>
           {{/* Appearance switcher */}}
           {{ if .Site.Params.footer.showAppearanceSwitcher | default false }}
             <li


### PR DESCRIPTION
- Empty params block not allowed in more recent version of Hugo (otherwise getting `panic: interface conversion: interface {} is nil, not maps.Params` error)
- Top-level params have to move down to params section